### PR TITLE
Update swayfx-9999.ebuild

### DIFF
--- a/gui-wm/swayfx/swayfx-9999.ebuild
+++ b/gui-wm/swayfx/swayfx-9999.ebuild
@@ -55,7 +55,7 @@ RDEPEND="
 "
 BDEPEND="
 	>=dev-libs/wayland-protocols-1.24
-	>=dev-util/meson-0.60.0
+	>=dev-build/meson-0.60.0
 	virtual/pkgconfig
 "
 BDEPEND+="man? ( >=app-text/scdoc-1.9.3 )"


### PR DESCRIPTION
Upstream category name change for meson.

https://github.com/gentoo/gentoo/commit/21b3f9ceef131258a721b1b29e52d0f9c4fd2ea4